### PR TITLE
Support compilation on stable Rust channels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! See the [C API docs](http://emcrisostomo.github.io/fswatch/doc/1.9.3/libfswatch.html/libfswatch_8h.html).
 
 #![allow(non_camel_case_types)]
-#![feature(const_fn)]
 
 extern crate libc;
 #[macro_use]


### PR DESCRIPTION
I'm not entirely sure what this changes, but I removed this and it seems to compile on stable now. Any chance this can be merged & pushed to crates?

Very much want to use `fswatch` but it won't compile on stable due to this issue.